### PR TITLE
Removed Redux setup in IntroductionPage for props that are already available to SaveInProgressIntro

### DIFF
--- a/generators/form/templates/IntroductionPage.jsx.ejs
+++ b/generators/form/templates/IntroductionPage.jsx.ejs
@@ -1,11 +1,9 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import { focusElement } from '<%= subFolder %>../../../platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation/OMBInfo';
 import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
-import SaveInProgressIntro, { introActions, introSelector } from '<%= subFolder %>../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from '<%= subFolder %>../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
 
 class IntroductionPage extends React.Component {
@@ -23,8 +21,6 @@ class IntroductionPage extends React.Component {
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the Application"
-          {...this.props.saveInProgressActions}
-          {...this.props.saveInProgress}>
           Please complete the <%= formNumber %> form to apply for <%= benefitDescription %>.
         </SaveInProgressIntro>
         <h4>Follow the steps below to apply for <%= benefitDescription %>.</h4>
@@ -58,8 +54,6 @@ class IntroductionPage extends React.Component {
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the Application"
-          {...this.props.saveInProgressActions}
-          {...this.props.saveInProgress}/>
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
           <OMBInfo resBurden={<%= respondentBurden %>} ombNumber="<%= ombNumber %>" expDate="<%= expirationDate %>"/>
         </div>
@@ -68,18 +62,4 @@ class IntroductionPage extends React.Component {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    saveInProgress: introSelector(state)
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    saveInProgressActions: bindActionCreators(introActions, dispatch)
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(IntroductionPage);
-
-export { IntroductionPage };
+export default IntroductionPage;


### PR DESCRIPTION
While working on updating the CTAs for forms, I noticed that pretty much all of the `IntroductionPage`s were essentially mapping/binding things from `SaveInProgressIntro` only to pass them back along as props to `SaveInProgressIntro`, which is already a container and can map its own props. There are a few edge cases where some intro pages directly reference the `user` state or require the `toggleLoginModal` action, but those one-offs could just directly import as needed.

Does it make sense to remove this logic from `IntroductionPage`? I've already started working on updating the existing `IntroductionPage`s and `SaveInProgressIntro` accordingly.