### PR TITLE
Fix errors/outdated generator references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Removed Redux setup in IntroductionPage for props that are already available to SaveInProgressIntro
 - Updated documentation links
+- renamed `jean-pants` to `formation`
+- `us-forms-system` moved to `platform/forms-system`
 ## [3.2.0] - 2018-08-10
 ### Added
 - New complex form template that has the following features:

--- a/generators/app/templates/entry.scss
+++ b/generators/app/templates/entry.scss
@@ -1,1 +1,1 @@
-@import "~@department-of-veterans-affairs/jean-pants/sass/shared-variables";
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";

--- a/generators/form/templates/IntroductionPage.jsx.ejs
+++ b/generators/form/templates/IntroductionPage.jsx.ejs
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { focusElement } from '<%= subFolder %>../../../platform/utilities/ui';
-import OMBInfo from '@department-of-veterans-affairs/formation/OMBInfo';
+import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from '<%= subFolder %>../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
@@ -20,7 +20,7 @@ class IntroductionPage extends React.Component {
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
-          startText="Start the Application"
+          startText="Start the Application">
           Please complete the <%= formNumber %> form to apply for <%= benefitDescription %>.
         </SaveInProgressIntro>
         <h4>Follow the steps below to apply for <%= benefitDescription %>.</h4>
@@ -53,7 +53,7 @@ class IntroductionPage extends React.Component {
           buttonOnly
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
-          startText="Start the Application"
+          startText="Start the Application"/>
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
           <OMBInfo resBurden={<%= respondentBurden %>} ombNumber="<%= ombNumber %>" expDate="<%= expirationDate %>"/>
         </div>

--- a/generators/form/templates/IntroductionPage.jsx.ejs
+++ b/generators/form/templates/IntroductionPage.jsx.ejs
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { focusElement } from '<%= subFolder %>../../../platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation/OMBInfo';
-import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from '<%= subFolder %>../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
 

--- a/generators/form/templates/formComplex.js.ejs
+++ b/generators/form/templates/formComplex.js.ejs
@@ -9,11 +9,11 @@ import fullSchema from '../<%= formNumber %>-schema.json';
 // imported above would import and use these common definitions:
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 
-import fullNameUI from 'us-forms-system/lib/js/definitions/fullName';
-import ssnUI from 'us-forms-system/lib/js/definitions/ssn';
-import bankAccountUI from 'us-forms-system/lib/js/definitions/bankAccount';
-import phoneUI from 'us-forms-system/lib/js/definitions/phone';
-import * as address from 'us-forms-system/lib/js/definitions/address';
+import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
+import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
+import bankAccountUI from 'platform/forms-system/src/js/definitions/bankAccount';
+import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import * as address from 'platform/forms-system/src/js/definitions/address';
 
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';

--- a/generators/form/templates/toursOfDuty.js.ejs
+++ b/generators/form/templates/toursOfDuty.js.ejs
@@ -1,4 +1,4 @@
-import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
+import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import ServicePeriodView from '<%= subFolder %>../../../platform/forms/components/ServicePeriodView';
 
 export default {


### PR DESCRIPTION
as of department-of-veterans-affairs/vets-website#9632 we use platform/forms-system 

and as of https://github.com/department-of-veterans-affairs/vets-website/pull/7721 `jean-pants` is called `formation`

Also, closing brackets were missingin generators/form/templates/IntroductionPage.jsx.ejs