### PR TITLE
Add page to content repo

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -160,11 +160,6 @@ module.exports = class extends Generator {
       this.props,
     );
     this.fs.copyTpl(
-      this.templatePath('index.md.ejs'),
-      this.destinationPath(`content/pages${this.props.rootUrl}.md`),
-      this.props,
-    );
-    this.fs.copyTpl(
       this.templatePath('e2e.spec.js.ejs'),
       this.destinationPath(`${appPath}/tests/00.${this.props.entryName}.e2e.spec.js`),
       this.props,

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,7 +1,23 @@
 'use strict';
+const fs = require('fs');
+const path = require('path');
 const Generator = require('yeoman-generator');
 const chalk = require('chalk');
 const yosay = require('yosay');
+
+const defaultContentRepoPath = '../vagov-content';
+
+const trimSlashes = val => {
+  // Add leading slash if needed
+  if (!val.startsWith('/')) {
+    val = `/${val}`;
+  }
+  // Add `index` if a page name was not included
+  if (val.endsWith('/')) {
+    val = `${val}index`;
+  }
+  return val;
+};
 
 module.exports = class extends Generator {
   prompting() {
@@ -69,17 +85,7 @@ module.exports = class extends Generator {
         name: 'rootUrl',
         message:
           "What's the root url for this app? Examples: '/gi-bill-comparison-tool' or '/education/opt-out-information-sharing/opt-out-form-0993'",
-        filter: val => {
-          // Add leading slash if needed
-          if (!val.startsWith('/')) {
-            val = `/${val}`;
-          }
-          // Add `index` if a page name was not included
-          if (val.endsWith('/')) {
-            val = `${val}index`;
-          }
-          return val;
-        },
+        filter: trimSlashes,
         default: answers => `/${answers.folderName}`,
       },
       {
@@ -88,6 +94,14 @@ module.exports = class extends Generator {
         message: 'Is this a form app?',
         default: false,
       },
+      {
+	type: 'input',
+	name: 'contentRepoLocation',
+	when: () => !fs.existsSync(path.join(this.destinationRoot(), defaultContentRepoPath)),
+	default: '../vagov-content',
+	message: "Where can I find the vagov-content repo? This path can be absolute or relative to vets-website.",
+        filter: trimSlashes,
+      }
     ];
 
     return this.prompt(prompts).then(props => {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -10,10 +10,9 @@ const defaultContentRepoPath = '../vagov-content';
 function hasAccessTo(location) {
   try {
     fs.accessSync(location, fs.constants.F_OK | fs.constants.W_OK);
-    return path.resolve(location);
+    return true;
   } catch (e) {
-    // Couldn't find it / don't have write permissions
-    return null;
+    return false;
   }
 }
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -97,10 +97,13 @@ module.exports = class extends Generator {
       {
 	type: 'input',
 	name: 'contentRepoLocation',
-	when: () => !fs.existsSync(path.join(this.destinationRoot(), defaultContentRepoPath)),
-	default: '../vagov-content',
-	message: "Where can I find the vagov-content repo? This path can be absolute or relative to vets-website.",
+	when: () => !fs.statSync(
+	  path.join(this.destinationRoot(), defaultContentRepoPath)
+	).isDirectory(),
+	message: 'Where can I find the vagov-content repo? This path can be absolute or relative to vets-website.',
         filter: trimSlashes,
+	// Assumes read / write access
+	validate: repoPath => fs.statSync(repoPath).isDirectory() || `Could not find the directory ${path.normalize(repoPath)}`,
       }
     ];
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -96,7 +96,7 @@ module.exports = class extends Generator {
         type: 'input',
         name: 'contentRepoLocation',
         message:
-          'Where can I find the vagov-content repo? This path can be absolute or relative to vets-website. (Leave blank to skip this step.)',
+          'Where can I find the vagov-content repo? This path can be absolute or relative to vets-website.',
         default: () => {
           const location = path.join(this.destinationRoot(), defaultContentRepoPath);
           try {
@@ -152,21 +152,19 @@ module.exports = class extends Generator {
     let contentRepoMarkdownCopied = false;
 
     // Vagov-content files
-    if (this.props.contentRepoLocation) {
-      try {
-        this.fs.copyTpl(
-          this.templatePath('index.md.ejs'),
-          path.join(this.props.contentRepoLocation, 'pages', `${this.props.rootUrl}.md`),
-          this.props,
-        );
-        contentRepoMarkdownCopied = true;
-      } catch (e) {
-        this.log(
-          chalk.red(
-            `Could not write to ${this.props.contentRepoLocation}; skipping this step.`,
-          ),
-        );
-      }
+    try {
+      this.fs.copyTpl(
+        this.templatePath('index.md.ejs'),
+        path.join(this.props.contentRepoLocation, 'pages', `${this.props.rootUrl}.md`),
+        this.props,
+      );
+      contentRepoMarkdownCopied = true;
+    } catch (e) {
+      this.log(
+        chalk.red(
+          `Could not write to ${this.props.contentRepoLocation}; skipping this step.`,
+        ),
+      );
     }
 
     // Normal vets-website files

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -100,10 +100,14 @@ module.exports = class extends Generator {
 	when: () => !fs.statSync(
 	  path.join(this.destinationRoot(), defaultContentRepoPath)
 	).isDirectory(),
-	message: 'Where can I find the vagov-content repo? This path can be absolute or relative to vets-website.',
+	message: 'Where can I find the vagov-content repo? This path can be absolute or relative to vets-website. (Leave blank to skip this step.)',
         filter: trimSlashes,
 	// Assumes read / write access
-	validate: repoPath => fs.statSync(repoPath).isDirectory() || `Could not find the directory ${path.normalize(repoPath)}`,
+	validate: repoPath => {
+	  if (repoPath)
+	    return fs.statSync(repoPath).isDirectory() || `Could not find the directory ${path.normalize(repoPath)}`;
+	  return true;
+	}
       }
     ];
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -6,7 +6,7 @@ const yosay = require('yosay');
 module.exports = class extends Generator {
   prompting() {
     // Have Yeoman greet the user.
-    this.log(yosay(`Welcome to the ${chalk.red('vets-website')} generator!`));
+    this.log(yosay(`Welcome to the ${chalk.red('vets-website app')} generator!`));
     this.log(
       `If you are new to this generator, you might want to read: 'Tutorial - Creating Your First Form' at:\n${chalk.cyan(
         'https://github.com/department-of-veterans-affairs/vets-external-teams/blob/master/DeveloperDocs/vets-website/forms/form-tutorial-basic.md',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -195,5 +195,10 @@ module.exports = class extends Generator {
         this.destinationPath(`${appPath}/routes.jsx`),
       );
     }
+
+    if (contentRepoMarkdownCopied)
+      this.log("Don't forget to make a pull request for vagov-content!");
+    else
+      this.log(`Don't forget to make a markdown file in the vagov-content repo at pages${this.props.rootUrl}.md!`);
   }
 };

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -7,6 +7,16 @@ const yosay = require('yosay');
 
 const defaultContentRepoPath = '../vagov-content';
 
+function hasAccessTo(location) {
+  try {
+    fs.accessSync(location, fs.constants.F_OK | fs.constants.W_OK);
+    return path.resolve(location);
+  } catch (e) {
+    // Couldn't find it / don't have write permissions
+    return null;
+  }
+}
+
 module.exports = class extends Generator {
   prompting() {
     // Have Yeoman greet the user.
@@ -99,27 +109,11 @@ module.exports = class extends Generator {
           'Where can I find the vagov-content repo? This path can be absolute or relative to vets-website.',
         default: () => {
           const location = path.join(this.destinationRoot(), defaultContentRepoPath);
-          try {
-            fs.accessSync(location, fs.constants.F_OK | fs.constants.W_OK);
-            this.log(`Can access ${path.resolve(location)}`);
-            return path.resolve(location);
-          } catch (e) {
-            // Couldn't find it / don't have write permissions
-            this.log(`Could NOT access ${path.resolve(location)}`);
-            return null;
-          }
+          return hasAccessTo(location) ? path.resolve(location) : null;
         },
-        validate: repoPath => {
-          if (repoPath) {
-            try {
-              fs.accessSync(repoPath, fs.constants.F_OK | fs.constants.W_OK);
-              return true;
-            } catch (e) {
-              return `Could not find the directory ${path.normalize(repoPath)}`;
-            }
-          }
-          return true;
-        },
+        validate: repoPath =>
+          hasAccessTo(repoPath) ||
+          `Could not find the directory ${path.normalize(repoPath)}`,
       },
     ];
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -138,6 +138,22 @@ module.exports = class extends Generator {
     const rootPath = `src/applications/`;
     const appPath = `${rootPath}${this.props.folderName}`;
 
+    // vagov-content files
+    let contentRepoMarkdownCopied = false;
+    if (this.props.contentRepoLocation) {
+      try {
+	this.fs.copyTpl(
+	  this.templatePath('index.md.ejs'),
+	  path.join(this.props.contentRepoLocation, 'pages', `${this.props.rootUrl}.md`,),
+	  this.props,
+	);
+	contentRepoMarkdownCopied = true;
+      } catch (e) {
+	this.log(chalk.red(`Could not write to ${this.props.contentRepoLocation}; skipping this step.`))
+      }
+    }
+    
+    // Normal vets-website files
     this.fs.copyTpl(
       this.templatePath('manifest.json.ejs'),
       this.destinationPath(`${appPath}/manifest.json`),
@@ -159,6 +175,7 @@ module.exports = class extends Generator {
       this.props,
     );
 
+    // Form files
     if (!this.props.isForm) {
       this.fs.copy(
         this.templatePath('entry.scss'),

--- a/generators/app/templates/index.md.ejs
+++ b/generators/app/templates/index.md.ejs
@@ -3,4 +3,5 @@ title: <%= appName %>
 entryname: <%= entryName %>
 layout: page-react.html
 includeBreadcrumbs: true
+vagovprod: false
 ---


### PR DESCRIPTION
## Description
As outlined in the connected ticket, the idea here was to add a page to the `vagov-content` repo because that's where we're housing the React app "kickstarter" files (that's...probably not the real term). Previously, we had these in `content/pages/` but that's no longer a thing.

## Screenshots
When we can't find the content repo or don't have write access to it:
![image](https://user-images.githubusercontent.com/12970166/61981461-9f1a9300-afae-11e9-95f4-a643c8ee515d.png)

When we _can_ find the content repo and have write access to it, we use that as the default:
![image](https://user-images.githubusercontent.com/12970166/61981492-b3f72680-afae-11e9-86ac-9d8da3b1c80e.png)

I was originally just not going to ask this question if we found it automagically, but that got a little clunky, so I figured this kind of visibility was probably better anyhow.

It does, indeed, create the file in the expected place and it all works beautifully:
![image](https://user-images.githubusercontent.com/12970166/61981625-09333800-afaf-11e9-9771-0144821d899f.png)
