### PR TITLE
disable E2E test in CI when app is not in prod

### DIFF
--- a/generators/app/templates/e2e.spec.js.ejs
+++ b/generators/app/templates/e2e.spec.js.ejs
@@ -13,5 +13,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
 });
 
 module.exports['@disabled'] =
-  !registry.find(entry => entry.appName === manifest.appName) ||
+  !registry.find(entry => entry.entryName === manifest.entryName) ||
   __BUILDTYPE__ !== 'production';
+  

--- a/generators/app/templates/e2e.spec.js.ejs
+++ b/generators/app/templates/e2e.spec.js.ejs
@@ -12,8 +12,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client.end();
 });
 
-
-const inProd = registry.find(entry => entry.appName === manifest.appName)
-
 module.exports['@disabled'] =
-  !inProd || __BUILDTYPE__ !== 'production';
+  !registry.find(entry => entry.appName === manifest.appName) ||
+  __BUILDTYPE__ !== 'production';

--- a/generators/app/templates/e2e.spec.js.ejs
+++ b/generators/app/templates/e2e.spec.js.ejs
@@ -14,6 +14,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
 // disable E2E test in CI if app is not in prod
 module.exports['@disabled'] =
-  !registry.find(entry => entry.entryName === manifest.entryName) &&
+  registry.find(entry => entry.entryName === manifest.entryName).template.vagovprod !== false &&
   __BUILDTYPE__ !== 'production';
   

--- a/generators/app/templates/e2e.spec.js.ejs
+++ b/generators/app/templates/e2e.spec.js.ejs
@@ -12,7 +12,8 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client.end();
 });
 
+// disable E2E test in CI if app is not in prod
 module.exports['@disabled'] =
-  !registry.find(entry => entry.entryName === manifest.entryName) ||
+  !registry.find(entry => entry.entryName === manifest.entryName) &&
   __BUILDTYPE__ !== 'production';
   

--- a/generators/app/templates/e2e.spec.js.ejs
+++ b/generators/app/templates/e2e.spec.js.ejs
@@ -1,6 +1,7 @@
 const Timeouts = require('platform/testing/e2e/timeouts');
 const E2eHelpers = require('platform/testing/e2e/helpers');
 const manifest = require('../manifest.json');
+const registry = require('applications/registry.json');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   client
@@ -11,5 +12,8 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client.end();
 });
 
+
+const inProd = registry.find(entry => entry.appName === manifest.appName)
+
 module.exports['@disabled'] =
-  !manifest.production || __BUILDTYPE__ !== 'production';
+  !inProd || __BUILDTYPE__ !== 'production';


### PR DESCRIPTION
big slack thread: https://dsva.slack.com/archives/CBU0KDSB1/p1590760884217600

tentative conclusion:
> @cvalarida Only disable the test if it's not in prod _and_ we're running in CI.
