### PR TITLE
OMBInfo moved to component library

### DIFF
--- a/generators/form/templates/IntroductionPage.jsx.ejs
+++ b/generators/form/templates/IntroductionPage.jsx.ejs
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { focusElement } from 'platform/utilities/ui';
-import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
+import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 


### PR DESCRIPTION
## Description

The `OMBInfo` component now lives in the component-library. Updating this in the `IntroductionPage` template.

## Acceptance criteria

- [x] `OMBInfo` is imported from the correct location