### PR TITLE
Updated form tester template to use new dataDir property.

### DIFF
--- a/generators/form/templates/cypress.spec.js.ejs
+++ b/generators/form/templates/cypress.spec.js.ejs
@@ -10,12 +10,10 @@ const testConfig = createTestConfig(
   {
     dataPrefix: 'data',
 
+    dataDir: path.join(__dirname, 'data'),
+
     // Rename and modify the test data as needed.
     dataSets: ['test-data'],
-
-    fixtures: {
-      data: path.join(__dirname, 'fixtures', 'data'),
-    },
 
     pageHooks: {
       introduction: ({ afterHook }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {


### PR DESCRIPTION
Cypress fixtures are being cleaned up in department-of-veterans-affairs/vets-website#17409.

One of the changes involves deprecating the `fixtures` property in form test configurations in favor of a `dataDir` property.

This change is to support the updated configuration.