### PR TITLE
update scroll to top function in form template

### DIFF
--- a/generators/form/templates/ConfirmationPage.jsx.ejs
+++ b/generators/form/templates/ConfirmationPage.jsx.ejs
@@ -1,23 +1,16 @@
 import React from 'react';
 import moment from 'moment';
 import { connect } from 'react-redux';
-import Scroll from 'react-scroll';
 
+import scrollToTop from 'platform/utilities/ui/scrollToTop'
 import { focusElement } from 'platform/utilities/ui';
 
-const scroller = Scroll.scroller;
-const scrollToTop = () => {
-  scroller.scrollTo('topScrollElement', {
-    duration: 500,
-    delay: 0,
-    smooth: true,
-  });
-};
+
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
     focusElement('.schemaform-title > h1');
-    scrollToTop();
+    scrollToTop('topScrollElement');
   }
 
   render() {


### PR DESCRIPTION
This PR reformats the form template in line with our centralizing effort for scroll functions to avoid any new forms getting created that do not follow the new structure.