### PR TITLE
Complex form generator should not use lodash/fp

### DIFF
--- a/generators/form/templates/formComplex.js.ejs
+++ b/generators/form/templates/formComplex.js.ejs
@@ -1,4 +1,4 @@
-import _ from 'lodash/fp';
+import { merge } from 'lodash';
 
 // Example of an imported schema:
 import fullSchema from '../<%= formNumber %>-schema.json';
@@ -170,7 +170,7 @@ const formConfig = {
             [formFields.viewNoDirectDeposit]: {
               'ui:title': 'I don’t want to use direct deposit',
             },
-            [formFields.bankAccount]: _.merge(bankAccountUI, {
+            [formFields.bankAccount]: merge({}, bankAccountUI, {
               'ui:order': [
                 formFields.accountType,
                 formFields.accountNumber,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {


### PR DESCRIPTION
## Description
Using merge from lodash instead of lodash/fp as it is included in the no-restricted-imports rule for `vet-website`'s .eslintrc

## Associated Issue(s)
#187

## Acceptance Criteria
- [x] lodash/fp is no longer used for imports