### PR TITLE
Remove lodash/fp import

### DIFF
--- a/generators/form/templates/formComplex.js.ejs
+++ b/generators/form/templates/formComplex.js.ejs
@@ -1,4 +1,4 @@
-import _ from 'lodash/fp';
+import _ from 'lodash';
 
 // Example of an imported schema:
 import fullSchema from '../<%= formNumber %>-schema.json';
@@ -170,7 +170,7 @@ const formConfig = {
             [formFields.viewNoDirectDeposit]: {
               'ui:title': 'I don’t want to use direct deposit',
             },
-            [formFields.bankAccount]: _.merge(bankAccountUI, {
+            [formFields.bankAccount]: _.merge({}, bankAccountUI, {
               'ui:order': [
                 formFields.accountType,
                 formFields.accountNumber,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {


### PR DESCRIPTION
## Description
It was discovered that `lodash/fp` is still being used in one of the templates. This causes linting to through an error after creating a new form.

[Slack thread](https://dsva.slack.com/archives/CBU0KDSB1/p1639510398019900)