### PR TITLE
Change UUID from user input to autogen

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -125,13 +125,6 @@ module.exports = class extends Generator {
       },
       {
         type: 'input',
-        name: 'productId',
-        message:
-          "Select a UUID for your application. This should not overlap with any other application IDs to avoid overlapping data. Check the product-directory in GitHub to verify yours is not in use.",
-        default: uuidv4(),
-      },
-      {
-        type: 'input',
         name: 'slackGroup',
         message:
           "What Slack user group should be notified for CI failures on the `main` branch? Example: '@vaos-fe-dev'",
@@ -148,6 +141,7 @@ module.exports = class extends Generator {
 
     return this.prompt(prompts).then(props => {
       this.props = props;
+      this.props.productId = uuidv4();
     });
   }
 
@@ -273,7 +267,7 @@ module.exports = class extends Generator {
         appName: this.props.appName,
         entryName: this.props.entryName,
         rootUrl: this.props.rootUrl,
-        productId: this. props.productId,
+        productId: this.props.productId,
         template: {
           vagovprod: false,
           layout: 'page-react.html',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.6.0",
+  "version": "3.6.5",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.6.5",
+  "version": "3.7.0",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {


### PR DESCRIPTION
This PR is to prevent a user from putting in an improperly formatted ID. As we've evolved our product directory initiative, we have standardized a format we'd like IDs to come in, as well as added automated scanning that will depend on this UUID existing. We thought it best to remove the option for a user-controlled ID and leave it to be automatically generated correctly.