### PR TITLE
Update app generator for automation

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -4,7 +4,6 @@ const path = require('path');
 const Generator = require('yeoman-generator');
 const chalk = require('chalk');
 const yosay = require('yosay');
-const { check } = require('prettier');
 
 const defaultContentRepoPath = '../vagov-content';
 
@@ -57,16 +56,14 @@ module.exports = class extends Generator {
       type: String,
       required: false
     })
-    // Will overwrite if necessary
-    this.option('force', {
-      type: String,
-      required: true
-    })
   }
 
+  // Validators
   _isInvalidFolderName = folder => !folder.includes(' ') || 'Folder names should not include spaces';
-
   _isInvalidEntryName = entryName => !entryName.includes(' ') || 'Bundle names should not include spaces';
+  _isInvalidSlackGroup = userGroup => {
+    return userGroup !== 'none' && !userGroup.startsWith('@') ? `Slack user groups should begin with an at sign, '@'. Received: ${userGroup}` : true
+  }
 
   // Remove leading and trailing forward slashes
   _folderNameFilter= folder => {
@@ -91,21 +88,16 @@ module.exports = class extends Generator {
       return url;
   }
 
-  _isInvalidSlackGroup = userGroup => {
-    return userGroup !== 'none' && !userGroup.includes('@') ? "Slack user groups should begin with an at sign, '@'" : true
-  }
-
+ 
   initializing() {
-    // These don't require any validation
-
     this.props = {
       appName: this.options.appName,
       rootUrl: this.options.rootUrl,
       contentRepoLocation: this.options.contentLoc
     }
     
-    const makeBool = boolLike => {
-        
+
+    const makeBool = boolLike => {   
       switch (boolLike?.toUpperCase()) {
         case 'N':
         case 'FALSE':
@@ -268,9 +260,6 @@ module.exports = class extends Generator {
   }
 
   configuring() {
-    this.log(
-      `Configuring*****\n`,
-    );
     // This needs to run before writing to the app folder, so we can know if the root folder is new.
     this._updateAllowlist();
   }
@@ -353,9 +342,6 @@ module.exports = class extends Generator {
   }
 
   updateRegistry() {
-    this.log(
-      `updatingRegistry\n`,
-    );
     const registryFile = 'src/applications/registry.json';
     const registry = this.fs.readJSON(registryFile);
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -47,7 +47,8 @@ module.exports = class extends Generator {
     this.option('slackGroup', {
       type: String, 
       required: false, 
-    })              
+    })       
+    // Accepts boolean-like strings, i.e. "N" and "FALSE" => false, "Y" and "TRUE" => true       
     this.option('isForm', {
       type: String,
       required: false
@@ -108,7 +109,7 @@ module.exports = class extends Generator {
       }
     }
 
-    this.props.isForm = makeBool(this.options.isForm)
+    this.props.isForm = this.options.isForm != undefined ?  makeBool(this.options.isForm) : null;
 
     // Perform validations
     if(this.options.folderName) {
@@ -192,7 +193,8 @@ module.exports = class extends Generator {
         name: 'isForm',
         message: 'Is this a form app?',
         default: false,
-        when: this.props.isForm === undefined 
+        // If this prop was set from a command line argument, it will be a boolean at this point, otherwise ask.
+        when: typeof this.props.isForm != 'boolean'
       },
       {
         type: 'input',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -366,7 +366,5 @@ module.exports = class extends Generator {
         ),
       );
     }
-
-
   }
 };

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -221,7 +221,6 @@ module.exports = class extends Generator {
       },
     ];
 
-
     return this.prompt(prompts).then(props => {
       this.props = {...this.props, ...props};
       this.props.productId = uuidv4();
@@ -229,8 +228,6 @@ module.exports = class extends Generator {
   }
 
   _updateAllowlist() {
-
-
     const configPath = path.join('config', 'changed-apps-build.json');
     const config = this.fs.readJSON(configPath);
     const isNewApp = !fs.existsSync(
@@ -366,5 +363,7 @@ module.exports = class extends Generator {
         ),
       );
     }
+
+
   }
 };

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -344,7 +344,7 @@ module.exports = class extends Generator {
   }
 
   updateRegistry() {
-    const registryFile = 'src/applications/registry.json';
+    const registryFile = '../content-build/src/applications/registry.json';
     const registry = this.fs.readJSON(registryFile);
 
     try {


### PR DESCRIPTION
The Console UI supports a [Software Template](https://backstage.io/docs/features/software-templates/) process that can be used to scaffold apps.  https://github.com/department-of-veterans-affairs/platform-console-ui/issues/324 was created to try to use this process to scaffold VFS apps.  The templating process supports integration with `yeoman` which lets us use these generators to do so.  

The integration does not support interacting with command line prompts,  therefore I've extended the generator to allow the values that the prompts capture to (optionally) be passed via command line options.   With this in place the generator can be called with command line options to skip some -- or all -- of the prompts.

Attempts have been made to not change much beyond this at all so as to preserve backwards comparability.  

* Change have only been made to the `app` generator, not `form` 
* Example of how this can be called to skip all prompts: `yo @department-of-veterans-affairs/vets-website:app --appName=mike app--folderName=mike-app --entryName=mike-entry --slackGroup=none --rootUrl=mike-app-public/ --isForm=n --contentLoc=content-path`