### PR TITLE
Update cypress.spec.js.ejs

### DIFF
--- a/generators/app/templates/cypress.spec.js.ejs
+++ b/generators/app/templates/cypress.spec.js.ejs
@@ -3,13 +3,13 @@ import manifest from '../manifest.json';
 describe(manifest.appName, () => {
   // Skip tests in CI until the app is released.
   // Remove this block when the app has a content page in production.
-  before(() => {
+  // eslint-disable-next-line func-names
+  before(function() {
     if (Cypress.env('CI')) this.skip();
   });
 
   it('is accessible', () => {
-    cy.visit(manifest.rootUrl)
-      .injectAxe()
-      .axeCheck();
+    cy.visit(manifest.rootUrl);
+    cy.injectAxeThenAxeCheck();
   });
 });


### PR DESCRIPTION
This is a follow-on to #336, where I inadvertently introduced a bug in the e2e stress tests. This PR fixes that bug and fixes another linting error.