### PR TITLE
Add entryName to app entry template

### DIFF
--- a/generators/app/templates/app-entry.jsx.ejs
+++ b/generators/app/templates/app-entry.jsx.ejs
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startAppFromIndex({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,


### PR DESCRIPTION
This change will ensure that source app headers are sent for all newly created apps, improving the ability to see which apps are sending which requests in Datadog.

related: https://github.com/department-of-veterans-affairs/vets-website/pull/30190