### PR TITLE
Formation deprecation: remove shared-variables import from app generator

### DIFF
--- a/generators/app/templates/entry.scss
+++ b/generators/app/templates/entry.scss
@@ -1,1 +1,0 @@
-@import "~@department-of-veterans-affairs/formation/sass/shared-variables";

--- a/generators/form/templates/entry.scss.ejs
+++ b/generators/form/templates/entry.scss.ejs
@@ -1,4 +1,3 @@
-@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-process-list";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-form-process";
 @import "<%= subFolder %>../../../platform/forms/sass/m-schemaform";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {


### PR DESCRIPTION
This removes the `~@department-of-veterans-affairs/formation/sass/shared-variables` imports as part of the formation deprecation. These are being removed throughout vets-website and are being replaced with css-library imports.

Closes [3322](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3322)