### PR TITLE
Update forms tests file path

### DIFF
--- a/generators/form/index.js
+++ b/generators/form/index.js
@@ -211,7 +211,7 @@ module.exports = class extends Generator {
 
     const updateMissingJsonSchema = () => {
       if (!this.props.usesVetsJsonSchema) {
-        const filePath = './src/platform/forms/tests/forms.unit.spec.js';
+        const filePath = './src/platform/forms/tests/forms-config-validator.unit.spec.js';
         const regex = /(const missingFromVetsJsonSchema = \[)([\s\S]*?)(\];)/;
         const newEntry = `  VA_FORM_IDS.${this.props.formIdConst},`;
         tryUpdateRegexInFile(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {


### PR DESCRIPTION
The generator was giving an error because it couldn't find the forms.unit.spec.js file in vets-website when running `yarn new:app`:

```
Error @department-of-veterans-affairs/vets-website 

./src/platform/forms/tests/forms.unit.spec.js doesn't exist
error Command failed with exit code 1.
```

It looks like that path was changed to `src/platform/forms/tests/forms-config-validator.unit.spec.js` here:

- https://github.com/department-of-veterans-affairs/vets-website/pull/33565

Slack convo: https://dsva.slack.com/archives/CBU0KDSB1/p1737037825627559