### PR TITLE
Remove old module imports in favor of web components

### DIFF
--- a/generators/form/templates/entry.scss.ejs
+++ b/generators/form/templates/entry.scss.ejs
@@ -1,6 +1,3 @@
-@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-process-list";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-form-process";
 @import "<%= subFolder %>../../../platform/forms/sass/m-schemaform";
-@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-modal";
-@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-omb-info";
 @import "<%= subFolder %>../../../platform/forms/sass/m-form-confirmation";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {


### PR DESCRIPTION
There are some old module stylesheets getting imported that are no longer needed since applications should be using these web components instead:

- [va-process-list](https://design.va.gov/storybook/?path=/docs/uswds-va-process-list--docs)
- [va-omb-info](https://design.va.gov/storybook/?path=/docs/components-va-omb-info--docs)
- [va-modal](https://design.va.gov/storybook/?path=/docs/uswds-va-modal--docs)