### PR TITLE
Add FORM_ENGINE option to the form generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [3.14.0] - 2025-04-11
+### Changed
+- Added new TEMPLATE_TYPE for form apps to generate structure for FORM_ENGINE powered forms.
+
 ## [3.13.0] - 2025-04-04
 ### Changed
 - New question for using minimal header

--- a/generators/form/index.js
+++ b/generators/form/index.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const TEMPLATE_TYPES = {
   WITH_1_PAGE: 'WITH_1_PAGE',
   WITH_4_PAGES: 'WITH_4_PAGES',
+  FORM_ENGINE: 'FORM_ENGINE',
 };
 
 /**
@@ -94,6 +95,7 @@ module.exports = class extends Generator {
         choices: [
           `${TEMPLATE_TYPES.WITH_1_PAGE}: A form with 1 page - name and date of birth`,
           `${TEMPLATE_TYPES.WITH_4_PAGES}: A form with 4 pages - name and date of birth, identification information, mailing address, and phone and email`,
+          `${TEMPLATE_TYPES.FORM_ENGINE}: A form from Drupal using the shared Form Engine`,
         ],
         filter: (choice) => choice.split(':')[0],
       },
@@ -103,7 +105,7 @@ module.exports = class extends Generator {
       this.props = { ...this.options, ...props };
       this.props.formIdConst = `FORM_${this.props.formNumber.replace(/-/g, '_')}`;
       if (this.options.sharedProps) {
-        // Update these so that form/index.js can have access to them
+        // Update these so that app/index.js can have access to them
         this.options.sharedProps.usesMinimalHeader = this.props.usesMinimalHeader;
         this.options.sharedProps.benefitDescription = this.props.benefitDescription;
         this.options.sharedProps.formNumber = this.props.formNumber;
@@ -114,67 +116,72 @@ module.exports = class extends Generator {
   writing() {
     const appPath = `src/applications/${this.props.folderName}`;
 
-    this.fs.copyTpl(
-      this.templatePath('entry.scss.ejs'),
-      this.destinationPath(`${appPath}/sass/${this.props.entryName}.scss`),
-      this.props,
-    );
+    if (
+      this.props.templateType === TEMPLATE_TYPES.WITH_1_PAGE ||
+      this.props.templateType === TEMPLATE_TYPES.WITH_4_PAGES
+    ) {
+      this.fs.copyTpl(
+        this.templatePath('entry.scss.ejs'),
+        this.destinationPath(`${appPath}/sass/${this.props.entryName}.scss`),
+        this.props,
+      );
 
-    this.fs.copyTpl(
-      this.templatePath('reducer.js.ejs'),
-      this.destinationPath(`${appPath}/reducers/index.js`),
-      this.props,
-    );
+      this.fs.copyTpl(
+        this.templatePath('reducer.js.ejs'),
+        this.destinationPath(`${appPath}/reducers/index.js`),
+        this.props,
+      );
 
-    this.fs.copyTpl(
-      this.templatePath('App.jsx.ejs'),
-      this.destinationPath(`${appPath}/containers/App.jsx`),
-      this.props,
-    );
+      this.fs.copyTpl(
+        this.templatePath('App.jsx.ejs'),
+        this.destinationPath(`${appPath}/containers/App.jsx`),
+        this.props,
+      );
 
-    this.fs.copyTpl(
-      this.templatePath('routes.jsx.ejs'),
-      this.destinationPath(`${appPath}/routes.jsx`),
-      this.props,
-    );
+      this.fs.copyTpl(
+        this.templatePath('routes.jsx.ejs'),
+        this.destinationPath(`${appPath}/routes.jsx`),
+        this.props,
+      );
 
-    this.fs.copy(this.templatePath('tests'), this.destinationPath(`${appPath}/tests`));
+      this.fs.copy(this.templatePath('tests'), this.destinationPath(`${appPath}/tests`));
 
-    this.fs.copyTpl(
-      this.templatePath('cypress.spec.js.ejs'),
-      this.destinationPath(`${appPath}/tests/${this.props.entryName}.cypress.spec.js`),
-      this.props,
-    );
+      this.fs.copyTpl(
+        this.templatePath('cypress.spec.js.ejs'),
+        this.destinationPath(`${appPath}/tests/${this.props.entryName}.cypress.spec.js`),
+        this.props,
+      );
 
-    this.fs.copyTpl(
-      this.templatePath('IntroductionPage.jsx.ejs'),
-      this.destinationPath(`${appPath}/containers/IntroductionPage.jsx`),
-      this.props,
-    );
+      this.fs.copyTpl(
+        this.templatePath('IntroductionPage.jsx.ejs'),
+        this.destinationPath(`${appPath}/containers/IntroductionPage.jsx`),
+        this.props,
+      );
 
-    this.fs.copyTpl(
-      this.templatePath('ConfirmationPage.jsx.ejs'),
-      this.destinationPath(`${appPath}/containers/ConfirmationPage.jsx`),
-      this.props,
-    );
+      this.fs.copyTpl(
+        this.templatePath('ConfirmationPage.jsx.ejs'),
+        this.destinationPath(`${appPath}/containers/ConfirmationPage.jsx`),
+        this.props,
+      );
 
-    this.fs.copyTpl(
-      this.templatePath('pages/nameAndDateOfBirth.js.ejs'),
-      this.destinationPath(`${appPath}/pages/nameAndDateOfBirth.js`),
-      this.props,
-    );
+      this.fs.copyTpl(
+        this.templatePath('pages/nameAndDateOfBirth.js.ejs'),
+        this.destinationPath(`${appPath}/pages/nameAndDateOfBirth.js`),
+        this.props,
+      );
 
-    this.fs.copyTpl(
-      this.templatePath('constants.js.ejs'),
-      this.destinationPath(`${appPath}/constants.js`),
-      this.props,
-    );
+      this.fs.copyTpl(
+        this.templatePath('constants.js.ejs'),
+        this.destinationPath(`${appPath}/constants.js`),
+        this.props,
+      );
 
-    this.fs.copyTpl(
-      this.templatePath('form.js.ejs'),
-      this.destinationPath(`${appPath}/config/form.js`),
-      this.props,
-    );
+      this.fs.copyTpl(
+        this.templatePath('form.js.ejs'),
+        this.destinationPath(`${appPath}/config/form.js`),
+        this.props,
+      );
+    }
 
     if (this.props.templateType === TEMPLATE_TYPES.WITH_4_PAGES) {
       this.fs.copyTpl(
@@ -192,6 +199,14 @@ module.exports = class extends Generator {
       this.fs.copyTpl(
         this.templatePath('pages/phoneAndEmailAddress.js.ejs'),
         this.destinationPath(`${appPath}/pages/phoneAndEmailAddress.js`),
+        this.props,
+      );
+    }
+
+    if (this.props.templateType === TEMPLATE_TYPES.FORM_ENGINE) {
+      this.fs.copyTpl(
+        this.templatePath('formEngine.js.ejs'),
+        this.destinationPath(`${appPath}/app-entry.jsx`),
         this.props,
       );
     }

--- a/generators/form/templates/formEngine.js.ejs
+++ b/generators/form/templates/formEngine.js.ejs
@@ -15,7 +15,7 @@ startFormEngineApp({
 -%>
     {
       href: '<%= path %>',
-      label: '<%= parts[i].charAt(0).toUpperCase() + parts[i].slice(1).replace(/-/g, ' ') %>',
+      label: '<%= appName %>',
     },
 <% } -%>
   ],

--- a/generators/form/templates/formEngine.js.ejs
+++ b/generators/form/templates/formEngine.js.ejs
@@ -1,0 +1,22 @@
+import manifest from './manifest.json';
+import startFormEngineApp from '../shared/utils/startApp';
+
+startFormEngineApp({
+  formId: '<%= formIdConst %>',
+  rootUrl: manifest.rootUrl,
+  trackingPrefix: '<%= trackingPrefix %>',
+  breadcrumbs: [
+    { href: '/', label: 'VA.gov home' },
+<%
+  const parts = rootUrl.split('/').filter(Boolean);
+  let path = '';
+  for (let i = 0; i < parts.length; i++) {
+    path += '/' + parts[i];
+-%>
+    {
+      href: '<%= path %>',
+      label: '<%= parts[i].charAt(0).toUpperCase() + parts[i].slice(1).replace(/-/g, ' ') %>',
+    },
+<% } -%>
+  ],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {


### PR DESCRIPTION
Related to: https://github.com/department-of-veterans-affairs/va.gov-team/issues/96306

Adds an additional option to the form generator prompts that renders the appropriate app-entry structure for a form engine-powered form. Existing generators and their questions should function as before with no change to functionality. If the `FORM_ENGINE` option is selected as the type of form template to use, the new path kicks in.

Generator prompts via `npx yo`:
**Note skipping the overwrites for vets-website files, as FORM_ENGINE forms are not included in those files at this time.**
![Screenshot 2025-04-10 at 2 56 02 PM](https://github.com/user-attachments/assets/ceff92e8-f24d-4b43-9af4-d3b638f783ad)
![Screenshot 2025-04-10 at 2 56 09 PM](https://github.com/user-attachments/assets/79e74335-cde0-4fe1-ad07-49b7b32d8bf8)

Generated files in vets-website based on above prompt selections:
<img width="392" alt="Screenshot 2025-04-10 at 2 56 42 PM" src="https://github.com/user-attachments/assets/b5ea9860-80b0-43e0-aa98-035e6c7a85e9" />

content-build registry.json updated as expected:
![Screenshot 2025-04-10 at 2 56 55 PM](https://github.com/user-attachments/assets/920f8a3d-e5dc-40bd-85e0-e650f9e46eee)


Testing:
pull this branch & follow the `npm link` instructions also found in the readme of this repo in order to test generator changes in vets-website:


From the root of this repo (generator-vets-website):
```
# Create a symlink in your global node_modules to this module.
npm link
```

Run your modified generator in your local vets-website.
From the root of vets-website:

```
# Point vets-website's local generator to your newly linked global module.
npm link @department-of-veterans-affairs/generator-vets-website

# Start up Yeoman.
npx yo
#Choose to run generator-vets-website in the Yeoman prompt.
```

Due to the link, any further changes to the generator will automatically be included when you run it within your local vets-website repo.

When you're done testing your changes, clean up the links:

```
# From the root of vets-website:
npm unlink --no-save @department-of-veterans-affairs/generator-vets-website

# From the root of generator-vets-website:
npm unlink
```