### PR TITLE
fix: add missing lib directory to npm package and correct main entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [3.17.1] - 2025-10-07
+### Fixed
+- Added missing `lib` directory to npm package files to fix "Cannot find module" errors
+- Corrected `main` entry point from non-existent `generators/index.js` to `generators/app/index.js`
+
 ## [3.17.0] - 2025-09-18
 ### Added
 - Dry run modes (`--dry-run-interactive` and `--dry-run-non-interactive`) for testing generator output without creating files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/generator-vets-website",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "description": "Generate a React app for vets-website",
   "homepage": "",
   "author": {
@@ -8,9 +8,10 @@
   },
   "files": [
     "generators",
-    "utils"
+    "utils",
+    "lib"
   ],
-  "main": "generators/index.js",
+  "main": "generators/app/index.js",
   "keywords": [
     "VA",
     "vets.gov",


### PR DESCRIPTION


## Summary

- Add 'lib' directory to package.json files array to fix 'Cannot find module' errors
- Correct main entry point from non-existent 'generators/index.js' to 'generators/app/index.js'
- Bump version to 3.17.1